### PR TITLE
Stop the handler if running (avoid dispose error)

### DIFF
--- a/TeamServer/Controllers/HandlersController.cs
+++ b/TeamServer/Controllers/HandlersController.cs
@@ -170,8 +170,10 @@ namespace TeamServer.Controllers
             var handler = _server.GetHandler(name);
             if (handler is null)
                 return NotFound($"Handler '{name}' not found");
-            
-            handler.Stop();
+
+            if (handler.Running)
+                handler.Stop();
+
             _server.RemoveHandler(handler);
             
             return NoContent();


### PR DESCRIPTION
Hey

Found this while playing with your C2 dev course.
If you remove a listener that is already stopped, it will return an exception "The CancellationTokenSource has been disposed".

To test the exception, i have performed the following commands on the client:
```
handlers
create demo HTTP
start demo
stop demo
```

Then, with Postman, i sent a DELETE request on https://localhost:8443/api/v1/handlers/demo.
